### PR TITLE
Removed code only available in nightly builds

### DIFF
--- a/src/desktop_entries.rs
+++ b/src/desktop_entries.rs
@@ -111,11 +111,9 @@ impl DesktopEntriesControl {
             }
 
             // Skip if title could not be found in it's app manifest file
-            let Some(title) = game.get_title()? else {
-                continue;
-            };
-
-            self.create_entry(path_entry, path_box_art, &game.appid, title)?;
+            if let Some(title) = game.get_title()? {
+                self.create_entry(path_entry, path_box_art, &game.appid, title)?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
The "let..else" block isn't stable yet, and only builds with nightly versions of Rust. I've replaced it with code that works in the stable and beta branches.