### PR TITLE
Support rofi versions later than the base 1.7.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rofi-games"
 authors = ["Rolv Apneseth"]
 description = "A rofi plugin which adds a mode to list available games for launch along with their box art"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 license-file = "LICENSE"
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PLUGIN_NAME := games.so
 CARGO ?= cargo
 CARGO_TARGET_DIR ?= target
 CARGO_RELEASE_DIR ?= $(CARGO_TARGET_DIR)/release
+ROFI_VERSION := $(shell rofi -version)
 
 licensesdir ?= /usr/share/licenses/$(PKGNAME)
 
@@ -14,7 +15,17 @@ plugins_dir ?= $(if $(plugins_dir_pc),$(plugins_dir_pc),lib/rofi)
 plugin_path := "$(plugins_dir)/$(PLUGIN_NAME)"
 
 install:
-	cargo build --release --lib
+	# Set rust flags if running a version of `rofi` with changes newer than the base `1.7.5`
+	# See https://github.com/SabrinaJewson/rofi-mode.rs/issues/8#event-11112343153
+	# Examples of version outputs
+	#     rofi: Version: 1.7.5
+	#     rofi-git: Version: 1.7.5-187-gb43a82f8 (makepkg)
+	#     rofi-lbonn-wayland-git: Version: 1.7.5+wayland2-154-g36621af0 (makepkg)
+	if [[ "Version: 1.7.5" != "${ROFI_VERSION}" ]]; then \
+		RUSTFLAGS="--cfg rofi_next" cargo build --release --lib; \
+	else \
+	    cargo build --release --lib; \
+	fi
 
 	# Plugin
 	install -DT "$(CARGO_RELEASE_DIR)/$(LIB_NAME)" "$(DESTDIR)$(plugin_path)"


### PR DESCRIPTION
This should hopefully fix #7 since it will install `rofi-games` with `RUSTFLAGS="--cfg rofi_next"` to account for the ABI changes that are present in the latest changes for `rofi` and the [lbonn wayland fork of rofi](https://github.com/lbonn/rofi).

More info [here](https://github.com/SabrinaJewson/rofi-mode.rs/issues/8#event-11112343153) (thank you to the incredible author of [rofi-mode.rs](https://github.com/SabrinaJewson/rofi-mode.rs).