### PR TITLE
Reduce final library file size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [profile.release]
 strip = true
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Same changes as I made to `rofi-nerdy` [here](https://github.com/Rolv-Apneseth/rofi-nerdy/pull/1).

Reduced file size from 2.7M to 1.7M, but if any unforeseen issues arise I will revert some or all of these changes.