### PR TITLE
feat: support user-configured custom entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,7 +460,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -538,10 +547,14 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rofi-games"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
+ "dirs",
  "lib_game_detector",
  "rofi-mode",
+ "serde",
+ "shlex",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -572,18 +585,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -592,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
@@ -607,6 +620,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
@@ -685,14 +704,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.8"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.22.9",
 ]
 
 [[package]]
@@ -711,10 +730,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
  "indexmap",
+ "toml_datetime",
+ "winnow 0.5.19",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.6",
 ]
 
 [[package]]
@@ -961,6 +991,15 @@ name = "winnow"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rofi-games"
 authors = ["Rolv Apneseth"]
 description = "A rofi plugin which adds a mode to list available games for launch along with their box art"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 license-file = "LICENSE"
 
@@ -11,6 +11,10 @@ tracing = "0.1.40"
 rofi-mode = "0.4.0"
 lib_game_detector = "0.0.5"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+toml = "0.8.12"
+dirs = "5.0.1"
+serde = { version = "1.0.198", features = ["derive"] }
+shlex = "1.3.0"
 
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">rofi-games</h1>
 
-<p align="center">A rofi plugin which adds a mode that will list available games for launch along with their box art. Requires a good theme for the best results.</p>
+<p align="center">Game launching plugin for `rofi`. Requires a good theme for the best results.</p>
 
 <p align="center">
   <img src="https://img.shields.io/badge/License-GPL_v2-green.svg" alt="License: GPL v2" />
@@ -83,13 +83,42 @@ However, only games which have box art are valid for this launcher so not everyt
 - Steam
   - Not non-Steam games though, if anyone knows where the box art for these is stored let me know as I can't find them
 - Heroic Games Launcher (all sources, including Amazon, should work)
-  - The `GOG` source doesn't store the box art like the others, but the icons so they won't look good
+  - The `GOG` source doesn't store the box art like the others, but the icons, so they won't look good
 - Lutris
-  - Must have box/cover art configured. Some may already have cover art (like the Epic Games launcher) but I would reccommend having a look over at [SteamGridDB](https://www.steamgriddb.com/grids) if you want to look for a better one. To set the cover art, simply right click the entry in the Lutris library, select "Configure", and click on the left-most image to select a new image file.
+  - Must have box/cover art configured (or define a custom entry - see configuration section below). Some may already have cover art (like the Epic Games launcher) but I would recommend having a look over at [SteamGridDB](https://www.steamgriddb.com/grids) if you want to look for a better one. To set the cover art, simply right click the entry in the Lutris library, select "Configure", and click on the left-most image to select a new image file.
 - Bottles
-  - Only games which are in the Library and have a box/cover art are displayed
+  - Only games which are in the Library and have a box/cover art (or have box art defined in a custom entry - see configuration section below) are displayed
 
-## Acknowledgement
+## Configuration
+
+Custom entries, for unsupported games (or technically anything you want), can be made by creating a config file at `~/.config/rofi-games/config.toml` (`$XDG_CONFIG_HOME` is respected). Here is an example configuration:
+
+    ```toml
+    box_art_dir = "/home/rolv/.config/rofi-games/box-art"
+
+    [[entries]]
+    title = "GDLauncher"
+    launch_command = "gdlauncher"
+    path_box_art = "gdlauncher.png"
+    path_game_dir = "/opt/GDLauncher"
+
+    [[entries]]
+    title = "Cyberpunk 2077"
+    path_box_art = "/home/rolv/images/cyberpunk.png"
+    ```
+
+- The `box_art_dir` field is optional, but will be used if the `path_box_art` field of a given entry is not an absolute path.
+
+- In the first entry, a custom entry is defined for `GDLauncher`. All fields must be defined.
+
+- In the second entry, a game already detected by `rofi-games` is matched by the `title` field. The
+  custom entry is used to override certain fields for that entry, e.g. changing the box art image.
+  - This can also be used to set box art images for the sources listed above that require a box art
+  image defined in the launcher itself e.g. Lutris
+  - **Note:** if you have multiple entries which match a given title, doing this will override the fields
+      on the first match, and remove all the other matches
+
+## Credit
 
 The original idea belongs (as far as I know) to [@ntcarlson](https://github.com/ntcarlson), so big thanks to them. The original script I used to use for this was derived from [this Reddit post](https://www.reddit.com/r/unixporn/comments/p5b0qv/i3_misusing_rofi_as_a_game_launcher/) they shared.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,96 @@
+use dirs::config_dir;
+use lib_game_detector::data::{Game, GamesSlice};
+use serde::Deserialize;
+use std::{error::Error, fs::read_to_string};
+use tracing::{debug, error};
+
+use crate::utils::{get_launch_command, get_path_box_art, get_path_game_dir};
+
+#[derive(Deserialize, Debug)]
+pub struct Config {
+    box_art_dir: Option<String>,
+    entries: Vec<ConfigEntry>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ConfigEntry {
+    title: String,
+    launch_command: Option<String>,
+    path_box_art: Option<String>,
+    path_game_dir: Option<String>,
+}
+
+pub fn read_config() -> Option<Config> {
+    let path_config = config_dir()?.join("rofi-games").join("config.toml");
+
+    if !path_config.is_file() {
+        debug!("Config file not found at {path_config:?}");
+        return None;
+    }
+
+    debug!("Config file found at {:?}", &path_config);
+
+    let Ok(contents) = read_to_string(path_config) else {
+        error!("Could not read config file contents");
+        return None;
+    };
+
+    toml::from_str::<Config>(&contents)
+        .map_err(|e| {
+            error!("Error parsing config: {:?}", e.message());
+            if let Some(source) = e.source() {
+                error!("Caused by: {source}");
+            };
+        })
+        .ok()
+}
+
+pub fn add_custom_entries(entries: &GamesSlice, config: &Config) -> GamesSlice {
+    // Convert parsed config entries into a `GamesSlice`
+    let custom_entries: GamesSlice = config
+        .entries
+        .iter()
+        .filter_map(|entry| {
+            let ConfigEntry {
+                title,
+                launch_command: opt_launch_command,
+                path_box_art: opt_path_box_art,
+                path_game_dir: opt_path_game_dir,
+            } = entry;
+
+            let matching_entry = entries.iter().find(|e| &e.title == title);
+            if matching_entry.is_none()
+                && (opt_launch_command.is_none()
+                    || opt_path_game_dir.is_none()
+                    || opt_path_box_art.is_none())
+            {
+                error!("No matching entry found for the title '{title}'. All fields for the custom entry must be provided.");
+                return None;
+            };
+
+            let launch_command = get_launch_command(matching_entry, opt_launch_command, title)?;
+            let path_box_art = Some(get_path_box_art(matching_entry, opt_path_box_art, &config.box_art_dir, title)?);
+            let path_game_dir = Some(get_path_game_dir(matching_entry, opt_path_game_dir,
+                title)?);
+
+            Some(Game {
+                title: title.clone(),
+                launch_command,
+                path_box_art,
+                path_game_dir,
+            })
+        })
+        .collect();
+
+    // Combine base entries with custom ones
+    entries
+        .iter()
+        // Remove base entry if there is a custom entry to override it
+        // NOTE: This can also remove multiple base entries per custom entry, since base entries
+        // with the same title are allowed (from different sources). Not entirely sure how to avoid
+        // this, so for now, it's a _feature_
+        .filter(|g| custom_entries.iter().all(|c| c.title != g.title))
+        .cloned()
+        .chain(custom_entries.iter().cloned())
+        .collect()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use config::read_config;
 use lib_game_detector::{
     data::{Game, GamesSlice},
     get_detector,
@@ -6,6 +7,11 @@ use rofi_mode::{Action, Event};
 use std::process::{self, Command};
 use tracing::{debug, error};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+use crate::config::add_custom_entries;
+
+mod config;
+mod utils;
 
 struct Mode<'rofi> {
     entries: GamesSlice,
@@ -68,9 +74,21 @@ impl<'rofi> rofi_mode::Mode<'rofi> for Mode<'rofi> {
             .with(EnvFilter::from_default_env())
             .init();
 
-        let entries = get_detector()
-            .get_all_detected_games_with_box_art()
+        let mut entries = get_detector()
+            .get_all_detected_games()
             .ok_or_else(|| error!("Error getting games from detector."))?;
+
+        // TODO: Avoid all the cloning of `entries`
+        if let Some(config) = read_config() {
+            entries = add_custom_entries(&entries, &config);
+        };
+
+        // Filter out entries without box art
+        entries = entries
+            .iter()
+            .filter(|e| e.path_box_art.is_some())
+            .cloned()
+            .collect();
 
         Ok(Mode { entries, api })
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,91 @@
+use std::{
+    path::PathBuf,
+    process::Command,
+    sync::{Arc, Mutex},
+};
+
+use lib_game_detector::data::Game;
+use tracing::{error, warn};
+
+#[inline]
+pub fn get_launch_command(
+    matching_entry: Option<&Game>,
+    opt_launch_command: &Option<String>,
+    title: &str,
+) -> Option<Arc<Mutex<Command>>> {
+    match (matching_entry, opt_launch_command) {
+        (_, Some(c)) => {
+            let split_command = shlex::split(c)?;
+            let mut command = Command::new(&split_command[0]);
+            command.args(&split_command[1..]);
+            Some(Arc::new(Mutex::new(command)))
+        }
+        (Some(entry), None) => Some(entry.launch_command.clone()),
+        _ => {
+            error!("No launch command provided for the custom entry with title: '{title}'");
+            None
+        }
+    }
+}
+
+#[inline]
+pub fn get_path_box_art(
+    matching_entry: Option<&Game>,
+    opt_path_box_art: &Option<String>,
+    opt_path_box_art_dir: &Option<String>,
+    title: &str,
+) -> Option<PathBuf> {
+    match (matching_entry, opt_path_box_art) {
+        (_, Some(p)) => {
+            let path = match opt_path_box_art_dir {
+                Some(d) => {
+                    let path_dir = PathBuf::from(d);
+                    if path_dir.is_absolute() {
+                        path_dir.join(p)
+                    } else {
+                        warn!("Ignoring the given `box_art_dir` config option as it is not pointing to an absolute path");
+                        PathBuf::from(p)
+                    }
+                }
+                None => PathBuf::from(p),
+            };
+            if path.is_file() {
+                Some(path)
+            } else {
+                error!("The box art path provided for '{title}' could not be found at: {path:?}");
+                None
+            }
+        }
+        (Some(entry), None) => entry.path_box_art.clone(),
+        _ => {
+            error!("No path to the box art provided for the custom entry with title: '{title}'");
+            None
+        }
+    }
+}
+
+#[inline]
+pub fn get_path_game_dir(
+    matching_entry: Option<&Game>,
+    opt_path_game_dir: &Option<String>,
+    title: &str,
+) -> Option<PathBuf> {
+    match (matching_entry, opt_path_game_dir) {
+        (_, Some(p)) => {
+            let path = PathBuf::from(p);
+            if path.is_dir() {
+                Some(path)
+            } else {
+                error!("The game directory path provided for '{title}' could not be found: {p}");
+                None
+            }
+        }
+        (Some(entry), None) => entry.path_game_dir.clone(),
+        _ => {
+            error!(
+                "No path to the game directory provided for the custom entry with title: '{title}'"
+            );
+            None
+        }
+    }
+}

--- a/themes/games-default.rasi
+++ b/themes/games-default.rasi
@@ -27,6 +27,7 @@ configuration {
 }
 
 window {
+    fullscreen:                     true;
     height:                         100%;
     width:                          100%;
     transparency:                   "real";

--- a/themes/games-smaller.rasi
+++ b/themes/games-smaller.rasi
@@ -1,6 +1,8 @@
 @import "games-default"
 
 window {
+    fullscreen:                     false;
+    border-radius:                  10px;
     height:                         50%;
     width:                          50%;
 }


### PR DESCRIPTION
This aims to add support for a config file for defining custom entries. This allows the user to:

- Add new games (or anything else) to entries listed by `rofi-games`
- Override fields for games already detected by `lib_game_detector`, such as box art, for greater customisation
  - This also allows defining box art for detected games that don't have box art, allowing them to be displayed. This can be used for e.g. Lutris games, instead of setting the box art in Lutris itself