### PR TITLE
Fix display name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rofi-games"
 authors = ["Rolv Apneseth"]
 description = "A rofi plugin which adds a mode to list available games for launch along with their box art"
-version = "1.9.1"
+version = "1.9.2"
 edition = "2021"
 license-file = "LICENSE"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,9 @@ impl<'rofi> rofi_mode::Mode<'rofi> for Mode<'rofi> {
     const NAME: &'static str = "games\0";
 
     fn init(mut api: rofi_mode::Api<'rofi>) -> Result<Self, ()> {
-        api.set_display_name("Games");
+        if api.display_name().is_none() {
+            api.set_display_name("games");
+        };
 
         tracing_subscriber::registry()
             .with(fmt::layer().without_time().with_line_number(true))
@@ -76,7 +78,7 @@ impl<'rofi> rofi_mode::Mode<'rofi> for Mode<'rofi> {
 
         let mut entries = get_detector().get_all_detected_games();
 
-        // TODO: Avoid all the cloning of `entries`
+        // Add custom entries from config
         if let Some(config) = read_config() {
             entries = add_custom_entries(&entries, config);
         };

--- a/themes/games-default.rasi
+++ b/themes/games-default.rasi
@@ -11,18 +11,6 @@
 
 configuration {
     font:                           "Roboto 17";
-}
-
-element-text {
-    text-color: @text-color;
-}
-
-element-text selected {
-    text-color: @text-color-selected;
-}
-
-
-configuration {
     show-icons:                     true;
 }
 
@@ -37,8 +25,15 @@ window {
 }
 
 mainbox {
-    children:                       [inputbar-box, listview];
+    children:                       [prompt, inputbar-box, listview];
     padding:                        0px 0px;
+}
+
+prompt {
+    width:                          100%;
+    margin:                         10px 0px 0px 30px;
+    text-color:                     @important;
+    font:                           "Roboto Bold 27";
 }
 
 listview {
@@ -57,7 +52,7 @@ inputbar-box {
 
 inputbar {
     children:                       [textbox-prompt, entry];
-    margin:                         50px 0px 0px 0px;
+    margin:                         0px;
     background-color:               @primary;
     border:                         4px;
     border-color:                   @primary;
@@ -107,11 +102,17 @@ element-box {
 element-icon {
     padding:                        10px;
     cursor:                         inherit;
-    size:                           35%;
+    size:                           33%;
     margin:                         10px;
 }
 
 element-text {
     horizontal-align:               0.5;
     cursor:                         inherit;
+    text-color: @text-color;
 }
+
+element-text selected {
+    text-color: @text-color-selected;
+}
+

--- a/themes/games-smaller.rasi
+++ b/themes/games-smaller.rasi
@@ -12,6 +12,15 @@ listview {
     padding:                        30px;
 }
 
+prompt {
+    enabled:                        false;
+}
+
+inputbar {
+    margin:                         20px 0px 10px 0px;
+}
+
 element-icon {
-    size:       12%;
+    padding:                        0px 10px;
+    size:                           12%;
 }


### PR DESCRIPTION
Applies the same fix as [#6 for rofi-nerdy](https://github.com/Rolv-Apneseth/rofi-nerdy/pull/6), as well as changing the default theme to actually display the `prompt` widget. This will now show `games` as the display name by default, but also allow users to change this using the following `rofi` theme snippet:

```css
configuration {
    display-games: "";
}
```

If you wish to disable the prompt, as it was before, just do something like this with your custom theme to override the default:

```css
prompt {
    enabled: false;
}

inputbar {
    margin: 50px 0px 0px 0px;
}
```