### PR TITLE
feat: update `lib_game_detector` for Steam shortcuts (non-Steam games) support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +40,12 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "bytecount"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "cairo-rs"
@@ -74,6 +86,15 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "directories"
@@ -317,15 +338,16 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lib_game_detector"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e724a0512449256943df83f6cf66b4bf64aa7dd10a5fa8622a9e1150b6ae38e"
+checksum = "1039108f2a32b0f26b6c7a4e552d40d73900db9133be553d3aab6185b33a9093"
 dependencies = [
  "anyhow",
  "cfg-if",
  "directories",
  "itertools",
  "nom",
+ "steam_shortcuts_util",
  "thiserror",
  "tracing",
 ]
@@ -382,6 +404,17 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom_locate"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
 ]
 
 [[package]]
@@ -547,7 +580,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rofi-games"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "dirs",
  "lib_game_detector",
@@ -641,6 +674,18 @@ name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+
+[[package]]
+name = "steam_shortcuts_util"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0543ebdb23a93b196aceebc53f70cc5a573bb74248a974b3f5fa3883e6a89b6"
+dependencies = [
+ "ascii",
+ "crc32fast",
+ "nom",
+ "nom_locate",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,14 @@
 name = "rofi-games"
 authors = ["Rolv Apneseth"]
 description = "A rofi plugin which adds a mode to list available games for launch along with their box art"
-version = "1.9.2"
+version = "1.10.0"
 edition = "2021"
 license-file = "LICENSE"
 
 [dependencies]
 tracing = "0.1.40"
 rofi-mode = "0.4.0"
-lib_game_detector = "0.0.7"
+lib_game_detector = "0.0.8"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 toml = "0.8.13"
 dirs = "5.0.1"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,12 @@ Parsing of installed games has been extracted into a separate library: [lib_game
 However, only games which have box art are valid for this launcher so not everything detected by that will be available for launch here. The following sources are currently supported:
 
 - Steam
-  - Not non-Steam games though, if anyone knows where the box art for these is stored let me know as I can't find them
+  - Steam shortcuts (non-Steam games) are also supported, with a couple requirements:
+
+    1. Make sure to restart Steam at least once for new shortcuts to be detected
+    2. Ensure the shortcuts has a box art image, using either the Steam UI or checking out the configuration section below.
+        - To use the Steam UI, navigate to the Steam library page (where the different games' box art is shown) and find the desired shortcut, right-click -> Manage -> Set custom artwork
+
 - Heroic Games Launcher (all sources, including Amazon, should work)
   - The `GOG` source doesn't store the box art like the others, but the icons, so they won't look good
 - Lutris


### PR DESCRIPTION
In relation to #26 