### PR TITLE
Change fallback plugins directory in install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ sudo cp target/release/librofi_games.so /usr/lib/rofi/games.so
 ```
 
 - If you are using the latest changes from the `rofi` repo (e.g. `rofi-lbonn-wayland-git`, `rofi-git`), then the build step needs to be preceded by `RUSTFLAGS="--cfg rofi_next"` for it to work
+- The last `cp` command assumes that the `rofi` plugins directory is `/usr/lib/rofi`, which may not be the case for you. Use `pkg-config --variable pluginsdir rofi` to find the one for your system, though if there is no output from that command, you may need to just try `/usr/lib64/rofi` or `/usr/lib/rofi` (the install script in the `justfile` falls back to these in that order).
 
 ## Theme
 

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ LIB_NAME := "librofi_games.so"
 PLUGIN_NAME := "games.so"
 THEMES_DIR := "/usr/share/rofi/themes"
 LICENSES_DIR := "/usr/share/licenses/" + PKGNAME
-PLUGINS_DIR := `pkg-config --variable pluginsdir rofi || echo "/lib/rofi"`
+PLUGINS_DIR := `pkg-config --variable pluginsdir rofi || if test -d "/usr/lib64"; then echo "/usr/lib64/rofi"; else echo "/usr/lib/rofi"; fi`
 PLUGIN_PATH := join(PLUGINS_DIR, PLUGIN_NAME)
 
 # Set rust flags if running a version of `rofi` with changes newer than the base `1.7.5`
@@ -32,7 +32,7 @@ RUSTFLAGS := if `rofi -version` =~ '^Version: 1\.7\.5(?:\+wayland2)?$' { "" } el
 
 # List commands
 default:
-    @just --list
+    just --list
 
 # Build
 build:


### PR DESCRIPTION
This will fall back to `/usr/lib64` first, if that exists, otherwise `/usr/lib`