### PR TITLE
feat: remove box art requirement and more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rofi-games"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "dirs",
  "is-terminal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,9 +334,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lib_game_detector"
-version = "0.0.16"
+version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00e4597a0069cb0f3ed2786649d26df2d341eea80750d9fa64881e9b49c3a1e"
+checksum = "5073ed797da9da9b94ec31f6073e111aae417bebab5e322536ba6934a90c54f7"
 dependencies = [
  "cfg-if",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license-file = "LICENSE"
 [dependencies]
 tracing = "0.1.*"
 rofi-mode = "0.4.*"
-lib_game_detector = { version = "0.0.16" }
+lib_game_detector = { version = "0.0.18" }
 tracing-subscriber = { version = "0.3.*", features = ["env-filter"] }
 toml = "0.8.*"
 dirs = "5.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rofi-games"
 authors = ["Rolv Apneseth"]
 description = "A rofi plugin which adds a mode to list available games for launch along with their box art"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2021"
 license-file = "LICENSE"
 

--- a/README.md
+++ b/README.md
@@ -79,27 +79,31 @@ For the optimal experience, and to achieve what is shown in the demo image, use 
 
 Parsing of installed games has been extracted into a separate library: [lib_game_detector](https://github.com/Rolv-Apneseth/lib_game_detector)
 
-However, only games which have box art are valid for this launcher so not everything detected by that will be available for launch here. The following sources are currently supported:
+The following sources are currently supported:
 
 - Steam
-  - Steam shortcuts (non-Steam games) are also supported, just ensure the shortcuts has a box art image, using either the Steam UI or checking out the configuration section below.
+  - Steam shortcuts (non-Steam games) are also supported
 
 > [!TIP]
 > To add box art for a shortcut using the Steam UI, navigate to the Steam library page (where the different games' box art is shown) and find the desired shortcut, right-click -> Manage -> Set custom artwork
 
-- Heroic Games Launcher (all sources, including Amazon, should work)
-  - The `GOG` source doesn't store the box art like the others, but the icons, so they won't look good
+- Heroic Games Launcher (all sources, including Amazon and manually added games, should work)
+  - The `GOG` source doesn't store the box art like the others, but the icons, so they won't look good by default.
+
 - Lutris
-  - Must have box/cover art configured (or define a custom entry - see configuration section below). Some may already have cover art (like the Epic Games launcher) but I would recommend having a look over at [SteamGridDB](https://www.steamgriddb.com/grids) if you want to look for a better one. To set the cover art, simply right click the entry in the Lutris library, select "Configure", and click on the left-most image to select a new image file.
+
+> [!TIP]  
+> To set the cover art, simply right click the entry in the Lutris library, select "Configure", and click on the left-most image to select a new image file.
+
 - Bottles
-  - Only games which are in the Library and have a box/cover art (or have box art defined in a custom entry - see configuration section below) are displayed
+  - Only games which are in the Library are displayed
 
 - Instances from the following modded Minecraft launchers:
     1. Prism Launcher
     2. ATLauncher
 
 > [!NOTE]
-> Modded Minecraft instances are not shown by default (as they don't have box art), so look at the configuration section below to see how to match an instance title to define box art for it
+> Modded Minecraft instances don't have box art by default, so look at the configuration section below to see how to match an instance title to define box art for it. Titles are usually given in the form `Minecraft: {instance name}`
 
 ## Configuration
 
@@ -131,12 +135,17 @@ path_box_art = "fabulously_optimized.png"
 
 - The `box_art_dir` field is optional, but will be used if the `path_box_art` field of a given entry is not an absolute path.
 
+- The `path_box_art` is optional, and if `box_art_dir` is defined, it can just be a relative path within that directory.
+
+> [!TIP]
+> [SteamGridDB](https://www.steamgriddb.com/grids) is a great place to find box art images for games.
+
 - In the first entry, a custom entry is defined for `GDLauncher`. All fields must be defined, except for `path_game_dir`.
 
 - In the second entry, a game already detected by `lib_game_detector` is matched by the `title` field. The
   custom entry is used to override certain fields for that entry, e.g. changing the box art image.
-  - This can also be used to set box art images for the sources listed above that require a box art
-  image defined in the launcher itself e.g. Lutris
+  - This can also be used to set box art images for the sources listed above that don't provide box art
+  by default e.g. Lutris, Minecraft instances
 
 > [!WARNING]
 > If you have multiple games which match a given title (e.g. from multiple launchers), creating a custom entry will only override the fields on the first match, and other matches will be ignored. If you have multiple entries in your configuration file with the same title, they will override each other.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ path_box_art = "/home/rolv/images/cyberpunk.png"
 [[entries]]
 title = "Minecraft: Fabulously Optimized"
 path_box_art = "fabulously_optimized.png"
+
+# Hide/disable a title
+[[entries]]
+title = "THE FINALS"
+hide = true
 ```
 
 - The `box_art_dir` field is optional, but will be used if the `path_box_art` field of a given entry is not an absolute path.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ The following sources are currently supported:
 Custom entries, for unsupported games (or technically anything you want), can be made by creating a config file at `~/.config/rofi-games/config.toml` (`$XDG_CONFIG_HOME` is respected). Here is an example configuration:
 
 ```toml
+# Allows hiding any entries which don't have box art images defined
+hide_entries_without_box_art = false
 # Directory to find box art in if an absolute path is not given
 box_art_dir = "/home/rolv/.config/rofi-games/box-art"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,9 +98,6 @@ impl<'rofi> rofi_mode::Mode<'rofi> for Mode<'rofi> {
             add_custom_entries(&mut entries, config);
         };
 
-        // Filter out entries without box art
-        entries.retain(|e| e.path_box_art.is_some());
-
         Ok(Mode { entries, api })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@ use std::process::{self, Command};
 use tracing::{debug, error};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-use crate::config::add_custom_entries;
-
 mod config;
 
 struct Mode<'rofi> {
@@ -95,7 +93,7 @@ impl<'rofi> rofi_mode::Mode<'rofi> for Mode<'rofi> {
 
         // Add custom entries from config
         if let Some(config) = read_config() {
-            add_custom_entries(&mut entries, config);
+            config.apply(&mut entries);
         };
 
         Ok(Mode { entries, api })


### PR DESCRIPTION
- Remove (by default) the requirement for box art for entries, so there are less requirements for simply launching detected games
- Added a new config option to require box art for entries to be shown, for those who still prefer the old functionality
- Added a new config option to hide a specific entry
- Updated `lib_game_detector`, which includes a fix for incorrect parsing of Heroic Launcher's Epic Games titles (was parsing the DLC's name instead of the game's)