### PR TITLE
feat: fall back to icons if box art is not available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,9 +346,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lib_game_detector"
-version = "0.0.21"
+version = "0.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc188016607ec1de01035fa24d7cd390c42e95beede7c54ec99ab55c72e2b206"
+checksum = "3b5a494a1ec8d0ea3d1efa6f63b1bd894a26293f0cca927bec68d3fd43075f37"
 dependencies = [
  "cfg-if",
  "dirs 6.0.0",
@@ -598,7 +598,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rofi-games"
-version = "1.12.3"
+version = "1.13.0"
 dependencies = [
  "dirs 5.0.1",
  "is-terminal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,14 @@
 name = "rofi-games"
 authors = ["Rolv Apneseth"]
 description = "A rofi plugin which adds a mode to list available games for launch along with their box art"
-version = "1.12.3"
+version = "1.13.0"
 edition = "2021"
 license-file = "LICENSE"
 
 [dependencies]
 tracing = "0.1.*"
 rofi-mode = "0.5.*"
-lib_game_detector = { version = "0.0.21" }
+lib_game_detector = { version = "=0.0.22" }
 tracing-subscriber = { version = "0.3.*", features = ["env-filter"] }
 toml = "0.9.*"
 dirs = "5.0.1"

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ The following sources are currently supported:
 > To add box art for a shortcut using the Steam UI, navigate to the Steam library page (where the different games' box art is shown) and find the desired shortcut, right-click -> Manage -> Set custom artwork
 
 - Heroic Games Launcher (all sources, including Amazon and manually added games, should work)
-  - The `GOG` source doesn't store the box art like the others, but the icons, so they won't look good by default.
+  - The `GOG` source doesn't store the box art like the others, but rather the icons. Use the `fallback_to_icons`
+    (enabled by default) option in the configuration to at least show those (though they won't look ideal).
 
 - Lutris
 
@@ -122,6 +123,8 @@ Custom entries, for unsupported games (or technically anything you want), can be
 hide_entries_without_box_art = false
 # Directory to find box art in if an absolute path is not given
 box_art_dir = "/home/rolv/.config/rofi-games/box-art"
+# If the box art for a game is not found, fallback to using the icon
+fallback_to_icons = true
 
 # Define a new custom entry
 [[entries]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,11 +116,10 @@ impl<'rofi> rofi_mode::Mode<'rofi> for Mode<'rofi> {
         match event {
             // User accepted an option from the list
             Event::Ok { alt, selected } => {
-                match alt {
-                    // User selected entry regularly, attempt to launch game
-                    false => self.handle_regular_event_ok(selected),
-                    // User selected entry with alternative binding, attempt to open game's root directory
-                    true => self.handle_alt_event_ok(selected),
+                if alt {
+                    self.handle_alt_event_ok(selected)
+                } else {
+                    self.handle_regular_event_ok(selected)
                 }
             }
 


### PR DESCRIPTION
The feature is enabled by default so as to respect the previous behaviour of showing Heroic games from GOG, which only have icons, but can be disabled via the config.