### PR TITLE
fix(lib_game_detector): ignore entries which are uninstalled, or originate from Steam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,7 +604,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rofi-games"
-version = "1.17.3"
+version = "1.17.4"
 dependencies = [
  "byteorder",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,9 +376,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lib_game_detector"
-version = "0.0.34"
+version = "0.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d720e69e13d57405b8c693b8f042cd165118c9efa0785189de720705970d9ae"
+checksum = "726edef1337beeba73e6c3499fa24d1aaece4e1a87d99c2a0d3293fff903afbd"
 dependencies = [
  "cfg-if",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "3.1.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae323eb086579a3769daa2c753bb96deb95993c534711e0dbe881b5192906a06"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rofi-games"
 authors = ["Rolv Apneseth"]
 description = "A rofi plugin which adds a mode to list available games for launch along with their box art"
-version = "1.17.3"
+version = "1.17.4"
 edition = "2024"
 license-file = "LICENSE"
 rust-version = "1.89"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.89"
 [dependencies]
 tracing = "0.1"
 rofi-mode = "0.5"
-lib_game_detector = { version = "=0.0.34", default-features = false }
+lib_game_detector = { version = "=0.0.35", default-features = false }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 toml = { version = "1.0", default-features = false, features = [
   "std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ toml = { version = "1.0", default-features = false, features = [
 dirs = "6.0"
 serde = { version = "1.0", features = ["derive"] }
 shlex = "1.3"
-redb = "3.0"
+redb = "4.1"
 byteorder = "1.5"
 
 [dev-dependencies]


### PR DESCRIPTION
See:

- https://github.com/Rolv-Apneseth/lib_game_detector/issues/53
- https://github.com/Rolv-Apneseth/lib_game_detector/pull/54